### PR TITLE
java-boiler-craft 2.1.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ tasks {
     }
 
     patchPluginXml {
-        sinceBuild.set("222")
+        sinceBuild.set("232")
         untilBuild.set("233.*")
     }
 

--- a/src/main/kotlin/kr/craft/javaboilercraft/JavaBoilerCraftAction.kt
+++ b/src/main/kotlin/kr/craft/javaboilercraft/JavaBoilerCraftAction.kt
@@ -17,6 +17,7 @@ import com.intellij.psi.PsiClass
 import com.intellij.psi.search.GlobalSearchScope
 import com.intellij.psi.search.searches.AnnotatedElementsSearch
 import com.intellij.ui.components.JBList
+import kr.craft.javaboilercraft.completion.impl.restdoc.core.HttpMethodMapping
 import kr.craft.javaboilercraft.completion.impl.restdoc.core.MethodPropertiesPsiConverter
 import kr.craft.javaboilercraft.completion.impl.restdoc.core.MockMvcTestBoilerplateGenerator
 import kr.craft.javaboilercraft.util.EditorUtils.getIndent
@@ -113,7 +114,15 @@ class JavaBoilerCraftAction : AnAction() {
      * Shows a MemberChooser to select methods and returns the selected methods.
      */
     private fun showMemberChooserAndGetSelectedMethods(selectedControllerClass: PsiClass, project: Project): List<PsiMethodMember>? {
-        val methods = selectedControllerClass.methods.map { PsiMethodMember(it) }
+        val methods = selectedControllerClass.methods.filter {
+            memberMethod -> memberMethod.annotations.find { annotation ->
+                HttpMethodMapping.values().find { mapping ->
+                    annotation.qualifiedName?.contains(mapping.methodMapping) == true
+                } != null
+            } != null
+        }.map {
+            PsiMethodMember(it)
+        }
         val chooser = MemberChooser<ClassMember>(methods.toTypedArray(), false, true, project)
         chooser.title = "Select Methods to Generate MockMvc Test"
         chooser.show()

--- a/src/main/kotlin/kr/craft/javaboilercraft/JavaBoilerCraftAction.kt
+++ b/src/main/kotlin/kr/craft/javaboilercraft/JavaBoilerCraftAction.kt
@@ -98,12 +98,11 @@ class JavaBoilerCraftAction : AnAction() {
         classList: JBList<String?>,
         editor: Editor,
         onItemSelected: (String) -> Unit,
-    ) {
+    ){
         PopupChooserBuilder(classList)
             .setTitle("Select Controller Class to Generate MockMvc Test")
-            .setItemChoosenCallback {
-                val selectedClass = classList.selectedValue ?: ""
-                onItemSelected(selectedClass)
+            .setItemChosenCallback {
+                onItemSelected(classList.selectedValue ?: "")
             }
             .createPopup()
             .showInBestPositionFor(editor)

--- a/src/main/kotlin/kr/craft/javaboilercraft/completion/impl/restdoc/core/MethodPropertiesPsiConverter.kt
+++ b/src/main/kotlin/kr/craft/javaboilercraft/completion/impl/restdoc/core/MethodPropertiesPsiConverter.kt
@@ -115,8 +115,9 @@ object MethodPropertiesPsiConverter {
             httpMethodMapping
         else {
             HttpMethodMapping.values().find { httpMethod ->
-                (httpMethodAnnotation.findAttributeValue("method")?.text
-                    ?.contains(httpMethod.name) == true)
+                (httpMethodAnnotation.findAttributeValue("method")?.text?.
+                replace("RequestMethod.","")?.contains(httpMethod.name))?:false
+
             }
         }
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -22,8 +22,10 @@
         <li>generate constructors and builder patterns for a given class.</li>
     </ul>
 
-    When you input a class name and uses a dot, in test scope,
-    the plugin automatically generates boilerplate code for MockMvc tests for RestDocs.
+    When you input a class name and uses a dot,
+    or on the Generate menu, in test scope,
+    you can select RestController class and methods.
+    Then the plugin automatically generates boilerplate code for MockMvc tests for RestDocs.
 
     And You can choose between 'All Args Constructor' and 'Builder Completion'.
     If 'All Args Constructor' is selected, a constructor containing all parameters is automatically generated.


### PR DESCRIPTION
### updates
* update plugin description
* fix error for RequestMapping annotation
* replace deprecated method
* eliminate other methods except http annotated methods
